### PR TITLE
Deal better with wrong paths

### DIFF
--- a/demon
+++ b/demon
@@ -85,6 +85,11 @@ class DataProcessor:
 
     def parse_file(self, filename=''):
         analyze_file = self.get_latest_analyze_file() if filename == '' else filename
+
+        if not analyze_file:
+            self.logger('No ekos .analyze file(s) found.')
+            return
+
         self.logger(f"Parsing {analyze_file}")
         self.logger(f'Session started at: {self._dt_start_time}')
         file = open(analyze_file, 'r')
@@ -133,7 +138,11 @@ class DataProcessor:
 
     def get_latest_analyze_file(self):
         list_of_files = glob.glob(f'{self.analyze_base_path}*.analyze')
-        latest_file = max(list_of_files, key=os.path.getctime)
+        try:
+            latest_file = max(list_of_files, key=os.path.getctime)
+        except ValueError:  # max raises an exception if the iterable is empty
+            latest_file = None
+
         return latest_file
 
     def __init__(self):
@@ -244,7 +253,9 @@ class DEMonWidget(QtWidgets.QWidget):
             if data_updated:
                 self.__print_log('Ekos data parsed and uploaded correctly!')
             else:
-                self.__print_log('Could not update the data! Did you provide a valid token?')
+                self.__print_log(
+                    'Could not update the data! Did you provide a valid token? Do you have a *.analyze file available?'
+                )
         except Exception as e:
             print(f"Something went wrong:{str(e)}")
             self.__print_log(f"Something went wrong:{str(e)}")


### PR DESCRIPTION
If a wrong path was passed the log were showing an error related to max() acting on an empty iterable,
this change will deal with this case more gently, bubbling up the case and printing a more friendly message

```
01/04/2022 13: 50: 47 - No ekos .analyze file(s) found.
01/04/2022 13: 50: 48 - Could not update the data! Did you provide a valid token? Do you have a * .analyze file available?
```