### PR TITLE
Simplify getting host IP address

### DIFF
--- a/demon
+++ b/demon
@@ -201,16 +201,9 @@ class DEMonWidget(QtWidgets.QWidget):
         self.monitor_timer.stop()
 
     def get_ip(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.settimeout(0)
-        try:
-            # doesn't even have to be reachable
-            s.connect(('10.255.255.255', 1))
-            ip = s.getsockname()[0]
-        except Exception:
-            ip = '127.0.0.1'
-        finally:
-            s.close()
+        host_name = socket.gethostname()
+        ip = socket.gethostbyname(host_name)
+
         return ip
 
     @QtCore.pyqtSlot()


### PR DESCRIPTION
This change wants to simplify a bit the way the IP is obtained by avoid opening a socket and using `socket.gethostbyname` instead.


I tested this locally and it seems to work, but another test is more than welcome!